### PR TITLE
feat(plugin): execute lifecycle hooks on install and uninstall

### DIFF
--- a/apps/coreApi/src/__tests__/integration/fixtures/pluginLifecycle/nodeadmin-plugin.json
+++ b/apps/coreApi/src/__tests__/integration/fixtures/pluginLifecycle/nodeadmin-plugin.json
@@ -1,0 +1,22 @@
+{
+  "id": "@nodeadmin/plugin-lifecycle-fixture",
+  "version": "1.0.0",
+  "displayName": "Plugin Lifecycle Fixture",
+  "description": "Integration fixture for plugin install and uninstall lifecycle hooks",
+  "author": {
+    "name": "nodeAdmin Test Suite"
+  },
+  "engines": {
+    "nodeAdmin": ">=0.1.0"
+  },
+  "permissions": [
+    "plugin:lifecycle:test"
+  ],
+  "entrypoints": {
+    "server": "./dist/server/index.js"
+  },
+  "lifecycle": {
+    "onInstall": "./scripts/install.cjs",
+    "onUninstall": "./scripts/uninstall.cjs"
+  }
+}

--- a/apps/coreApi/src/__tests__/integration/fixtures/pluginLifecycle/package.json
+++ b/apps/coreApi/src/__tests__/integration/fixtures/pluginLifecycle/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@nodeadmin/plugin-lifecycle-fixture",
+  "private": true,
+  "version": "1.0.0",
+  "main": "./dist/server/index.js"
+}

--- a/apps/coreApi/src/__tests__/integration/fixtures/pluginLifecycle/scripts/install.cjs
+++ b/apps/coreApi/src/__tests__/integration/fixtures/pluginLifecycle/scripts/install.cjs
@@ -1,0 +1,8 @@
+module.exports = async function onInstall(context) {
+  await context.client.query(
+    `UPDATE tenant_plugins
+     SET config = jsonb_set(config, '{lifecycleInstalled}', 'true'::jsonb, true)
+     WHERE tenant_id = $1 AND plugin_name = $2`,
+    [context.tenantId, context.pluginId]
+  );
+};

--- a/apps/coreApi/src/__tests__/integration/fixtures/pluginLifecycle/scripts/uninstall.cjs
+++ b/apps/coreApi/src/__tests__/integration/fixtures/pluginLifecycle/scripts/uninstall.cjs
@@ -1,0 +1,22 @@
+const { writeFile } = require('node:fs/promises');
+
+module.exports = async function onUninstall(context) {
+  const markerPath = process.env.PLUGIN_LIFECYCLE_UNINSTALL_MARKER;
+
+  if (!markerPath) {
+    return;
+  }
+
+  await writeFile(
+    markerPath,
+    JSON.stringify(
+      {
+        pluginId: context.pluginId,
+        tenantId: context.tenantId,
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+};

--- a/apps/coreApi/src/__tests__/integration/pluginLifecycle.integration.test.ts
+++ b/apps/coreApi/src/__tests__/integration/pluginLifecycle.integration.test.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, readFile, symlink, unlink } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';

--- a/apps/coreApi/src/__tests__/integration/pluginLifecycle.integration.test.ts
+++ b/apps/coreApi/src/__tests__/integration/pluginLifecycle.integration.test.ts
@@ -1,0 +1,151 @@
+import { mkdtemp, readFile, symlink, unlink } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createIntegrationContext, type IntegrationContext } from './integrationHarness';
+
+const FIXTURE_PLUGIN_ID = '@nodeadmin/plugin-lifecycle-fixture';
+const FIXTURE_VERSION = '1.0.0';
+const FIXTURE_ROOT = resolve(
+  process.cwd(),
+  'apps/coreApi/src/__tests__/integration/fixtures/pluginLifecycle'
+);
+const FIXTURE_LINK_PATH = resolve(
+  process.cwd(),
+  'node_modules/@nodeadmin/plugin-lifecycle-fixture'
+);
+
+describe('plugin lifecycle integration', () => {
+  let context: IntegrationContext;
+  let pool: Pool;
+  let uninstallMarkerPath: string;
+
+  beforeAll(async () => {
+    uninstallMarkerPath = join(
+      await mkdtemp(join(tmpdir(), 'nodeadmin-plugin-lifecycle-')),
+      'uninstall.json'
+    );
+
+    await symlink(FIXTURE_ROOT, FIXTURE_LINK_PATH, 'dir').catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== 'EEXIST') {
+        throw error;
+      }
+    });
+
+    context = await createIntegrationContext({
+      PLUGIN_LIFECYCLE_UNINSTALL_MARKER: uninstallMarkerPath,
+    });
+    pool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+    });
+
+    await seedMarketplacePlugin(pool);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DELETE FROM tenant_plugins WHERE plugin_name = $1', [FIXTURE_PLUGIN_ID]);
+      await pool.query('DELETE FROM plugin_versions WHERE plugin_id = $1', [FIXTURE_PLUGIN_ID]);
+      await pool.query('DELETE FROM plugin_registry WHERE id = $1', [FIXTURE_PLUGIN_ID]);
+      await pool.end();
+    }
+    if (context) {
+      await context.close();
+    }
+    await unlink(FIXTURE_LINK_PATH).catch(() => undefined);
+  });
+
+  it('runs lifecycle hooks when a tenant installs and uninstalls a plugin', async () => {
+    const accessToken = await context.issueDevToken('plugin-admin', ['super-admin'], 'default');
+
+    const installResponse = await context.http
+      .post('/api/v1/admin/plugins/install')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        pluginId: FIXTURE_PLUGIN_ID,
+        version: FIXTURE_VERSION,
+      });
+
+    expect(installResponse.status).toBe(201);
+
+    const installedRow = await pool.query<{
+      config: Record<string, unknown>;
+      enabled: boolean;
+      installed_version: string | null;
+    }>(
+      `SELECT enabled, installed_version, config
+       FROM tenant_plugins
+       WHERE tenant_id = $1 AND plugin_name = $2`,
+      ['default', FIXTURE_PLUGIN_ID]
+    );
+
+    expect(installedRow.rows[0]).toMatchObject({
+      enabled: true,
+      installed_version: FIXTURE_VERSION,
+    });
+    expect(installedRow.rows[0]?.config.lifecycleInstalled).toBe(true);
+
+    const uninstallResponse = await context.http
+      .delete(`/api/v1/admin/plugins/${encodeURIComponent(FIXTURE_PLUGIN_ID)}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(uninstallResponse.status).toBe(200);
+
+    const remainingRow = await pool.query(
+      `SELECT 1
+       FROM tenant_plugins
+       WHERE tenant_id = $1 AND plugin_name = $2`,
+      ['default', FIXTURE_PLUGIN_ID]
+    );
+
+    expect(remainingRow.rowCount).toBe(0);
+
+    const uninstallMarker = JSON.parse(await readFile(uninstallMarkerPath, 'utf8')) as {
+      pluginId: string;
+      tenantId: string;
+    };
+
+    expect(uninstallMarker).toEqual({
+      pluginId: FIXTURE_PLUGIN_ID,
+      tenantId: 'default',
+    });
+  });
+});
+
+async function seedMarketplacePlugin(pool: Pool): Promise<void> {
+  const manifest = await readFile(join(FIXTURE_ROOT, 'nodeadmin-plugin.json'), 'utf8');
+
+  await pool.query(
+    `INSERT INTO plugin_registry (id, display_name, description, author_name, author_email, latest_version, is_public, download_count, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, NULL, $5, true, 0, now(), now())
+     ON CONFLICT (id)
+     DO UPDATE SET display_name = EXCLUDED.display_name,
+                   description = EXCLUDED.description,
+                   author_name = EXCLUDED.author_name,
+                   latest_version = EXCLUDED.latest_version,
+                   updated_at = now()`,
+    [
+      FIXTURE_PLUGIN_ID,
+      'Plugin Lifecycle Fixture',
+      'Integration fixture for plugin install and uninstall lifecycle hooks',
+      'nodeAdmin Test Suite',
+      FIXTURE_VERSION,
+    ]
+  );
+
+  await pool.query(
+    `INSERT INTO plugin_versions (plugin_id, version, manifest, bundle_url, server_package, min_platform_version, changelog, published_at)
+     VALUES ($1, $2, $3::jsonb, $4, $5, $6, NULL, now())
+     ON CONFLICT (plugin_id, version)
+     DO NOTHING`,
+    [
+      FIXTURE_PLUGIN_ID,
+      FIXTURE_VERSION,
+      manifest,
+      'https://example.invalid/plugin-lifecycle-fixture.js',
+      `${FIXTURE_PLUGIN_ID}@${FIXTURE_VERSION}`,
+      '>=0.1.0',
+    ]
+  );
+}

--- a/apps/coreApi/src/modules/plugin/pluginMarketService.test.ts
+++ b/apps/coreApi/src/modules/plugin/pluginMarketService.test.ts
@@ -202,7 +202,26 @@ describe('PluginMarketService', () => {
       const mockClient = createMockClient([
         { rows: [], rowCount: 0 },
         { rows: [], rowCount: 0 },
-        { rows: [{ version: '1.2.0', min_platform_version: '>=0.1.0' }], rowCount: 1 },
+        {
+          rows: [
+            {
+              manifest: {
+                author: { name: 'NodeAdmin Team' },
+                description: 'Board view',
+                displayName: 'Kanban',
+                engines: { nodeAdmin: '>=0.1.0' },
+                entrypoints: { server: './dist/server/index.js' },
+                id: '@nodeadmin/plugin-kanban',
+                permissions: ['backlog:view'],
+                version: '1.2.0',
+              },
+              min_platform_version: '>=0.1.0',
+              server_package: '@nodeadmin/plugin-kanban@1.2.0',
+              version: '1.2.0',
+            },
+          ],
+          rowCount: 1,
+        },
         { rows: [], rowCount: 1 },
         { rows: [], rowCount: 0 },
       ]);
@@ -233,7 +252,26 @@ describe('PluginMarketService', () => {
       const mockClient = createMockClient([
         { rows: [], rowCount: 0 },
         { rows: [], rowCount: 0 },
-        { rows: [{ version: '1.3.0', min_platform_version: '>=0.1.0' }], rowCount: 1 },
+        {
+          rows: [
+            {
+              manifest: {
+                author: { name: 'NodeAdmin Team' },
+                description: 'Board view',
+                displayName: 'Kanban',
+                engines: { nodeAdmin: '>=0.1.0' },
+                entrypoints: { server: './dist/server/index.js' },
+                id: '@nodeadmin/plugin-kanban',
+                permissions: ['backlog:view'],
+                version: '1.3.0',
+              },
+              min_platform_version: '>=0.1.0',
+              server_package: '@nodeadmin/plugin-kanban@1.3.0',
+              version: '1.3.0',
+            },
+          ],
+          rowCount: 1,
+        },
         { rows: [], rowCount: 1 },
         { rows: [], rowCount: 0 },
       ]);
@@ -257,6 +295,16 @@ describe('PluginMarketService', () => {
       const mockClient = createMockClient([
         { rows: [], rowCount: 0 },
         { rows: [], rowCount: 0 },
+        {
+          rows: [
+            {
+              installed_version: '1.2.0',
+              manifest: null,
+              server_package: null,
+            },
+          ],
+          rowCount: 1,
+        },
         { rows: [{ plugin_name: '@nodeadmin/plugin-kanban' }], rowCount: 1 },
         { rows: [], rowCount: 0 },
       ]);
@@ -272,8 +320,126 @@ describe('PluginMarketService', () => {
         tenantId: 'tenant-1',
       });
 
-      expect(mockClient.calls[2]?.sql).toContain('DELETE FROM tenant_plugins');
-      expect(mockClient.calls[2]?.params).toEqual(['tenant-1', '@nodeadmin/plugin-kanban']);
+      expect(mockClient.calls[2]?.sql).toContain('FROM tenant_plugins tp');
+      expect(mockClient.calls[3]?.sql).toContain('DELETE FROM tenant_plugins');
+      expect(mockClient.calls[3]?.params).toEqual(['tenant-1', '@nodeadmin/plugin-kanban']);
+    });
+
+    it('runs lifecycle hooks before removing an installed plugin', async () => {
+      const lifecycleHook = vi.fn(async () => undefined);
+      const hookModuleLoader = vi.fn(() => lifecycleHook);
+      const packageJsonResolver = vi.fn(
+        () => '/repo/node_modules/@nodeadmin/plugin-kanban/package.json'
+      );
+      const mockClient = createMockClient([
+        { rows: [], rowCount: 0 },
+        { rows: [], rowCount: 0 },
+        {
+          rows: [
+            {
+              installed_version: '1.2.0',
+              manifest: {
+                author: { name: 'NodeAdmin Team' },
+                description: 'Board view',
+                displayName: 'Kanban',
+                engines: { nodeAdmin: '>=0.1.0' },
+                entrypoints: { server: './dist/server/index.js' },
+                id: '@nodeadmin/plugin-kanban',
+                lifecycle: { onUninstall: './scripts/uninstall.cjs' },
+                permissions: ['backlog:view'],
+                version: '1.2.0',
+              },
+              server_package: '@nodeadmin/plugin-kanban@1.2.0',
+            },
+          ],
+          rowCount: 1,
+        },
+        { rows: [{ plugin_name: '@nodeadmin/plugin-kanban' }], rowCount: 1 },
+        { rows: [], rowCount: 0 },
+      ]);
+      const mockPool = createMockPool([]);
+      mockPool.connect = vi.fn(async () => mockClient);
+      (service as unknown as { pool: typeof mockPool }).pool = mockPool;
+      (service as unknown as { hookModuleLoader: typeof hookModuleLoader }).hookModuleLoader =
+        hookModuleLoader;
+      (
+        service as unknown as { packageJsonResolver: typeof packageJsonResolver }
+      ).packageJsonResolver = packageJsonResolver;
+
+      await service.uninstallPlugin('tenant-1', '@nodeadmin/plugin-kanban');
+
+      expect(packageJsonResolver).toHaveBeenCalledWith('@nodeadmin/plugin-kanban');
+      expect(hookModuleLoader).toHaveBeenCalledWith(
+        '/repo/node_modules/@nodeadmin/plugin-kanban/scripts/uninstall.cjs'
+      );
+      expect(lifecycleHook).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pluginId: '@nodeadmin/plugin-kanban',
+          tenantId: 'tenant-1',
+          version: '1.2.0',
+        })
+      );
+      expect(mockClient.calls[3]?.sql).toContain('DELETE FROM tenant_plugins');
+    });
+  });
+
+  describe('install lifecycle', () => {
+    it('runs lifecycle hooks after persisting an installed plugin', async () => {
+      const lifecycleHook = vi.fn(async () => undefined);
+      const hookModuleLoader = vi.fn(() => lifecycleHook);
+      const packageJsonResolver = vi.fn(
+        () => '/repo/node_modules/@nodeadmin/plugin-kanban/package.json'
+      );
+      const mockClient = createMockClient([
+        { rows: [], rowCount: 0 },
+        { rows: [], rowCount: 0 },
+        {
+          rows: [
+            {
+              manifest: {
+                author: { name: 'NodeAdmin Team' },
+                description: 'Board view',
+                displayName: 'Kanban',
+                engines: { nodeAdmin: '>=0.1.0' },
+                entrypoints: { server: './dist/server/index.js' },
+                id: '@nodeadmin/plugin-kanban',
+                lifecycle: { onInstall: './scripts/install.cjs' },
+                permissions: ['backlog:view'],
+                version: '1.2.0',
+              },
+              min_platform_version: '>=0.1.0',
+              server_package: '@nodeadmin/plugin-kanban@1.2.0',
+              version: '1.2.0',
+            },
+          ],
+          rowCount: 1,
+        },
+        { rows: [], rowCount: 1 },
+        { rows: [], rowCount: 0 },
+      ]);
+      const mockPool = createMockPool([]);
+      mockPool.connect = vi.fn(async () => mockClient);
+      (service as unknown as { pool: typeof mockPool }).pool = mockPool;
+      (service as unknown as { hookModuleLoader: typeof hookModuleLoader }).hookModuleLoader =
+        hookModuleLoader;
+      (
+        service as unknown as { packageJsonResolver: typeof packageJsonResolver }
+      ).packageJsonResolver = packageJsonResolver;
+
+      await service.installPlugin('tenant-1', '@nodeadmin/plugin-kanban', '1.2.0');
+
+      expect(packageJsonResolver).toHaveBeenCalledWith('@nodeadmin/plugin-kanban');
+      expect(hookModuleLoader).toHaveBeenCalledWith(
+        '/repo/node_modules/@nodeadmin/plugin-kanban/scripts/install.cjs'
+      );
+      expect(lifecycleHook).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pluginId: '@nodeadmin/plugin-kanban',
+          tenantId: 'tenant-1',
+          version: '1.2.0',
+        })
+      );
+      expect(mockClient.calls[3]?.sql).toContain('INSERT INTO tenant_plugins');
     });
   });
 

--- a/apps/coreApi/src/modules/plugin/pluginMarketService.ts
+++ b/apps/coreApi/src/modules/plugin/pluginMarketService.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { Pool, type PoolClient } from 'pg';
 import type { PluginManifest } from '@nodeadmin/shared-types';
@@ -29,6 +31,13 @@ interface InstallableVersion {
   version: string;
 }
 
+interface InstallPluginVersionRow {
+  manifest: PluginManifest;
+  min_platform_version: string | null;
+  server_package: string;
+  version: string;
+}
+
 interface PublishPluginInput {
   bundleUrl: string;
   changelog?: string;
@@ -36,10 +45,32 @@ interface PublishPluginInput {
   serverPackage: string;
 }
 
+interface InstalledPluginLifecycleRow {
+  installed_version: string | null;
+  manifest: PluginManifest | null;
+  server_package: string | null;
+}
+
+interface PluginLifecycleContext {
+  client: PoolClient;
+  manifest: PluginManifest;
+  pluginId: string;
+  tenantId: string;
+  version: string;
+}
+
+type HookModuleLoader = (modulePath: string) => unknown;
+type PackageJsonResolver = (packageName: string) => string;
+type PluginLifecycleHandler = (context: PluginLifecycleContext) => Promise<unknown> | unknown;
+
 @Injectable()
 export class PluginMarketService {
   private readonly platformVersion = '0.1.0';
   private readonly pool: Pool | null;
+  private readonly requireFromRoot = createRequire(resolve(process.cwd(), 'package.json'));
+  private hookModuleLoader: HookModuleLoader = (modulePath) => this.requireFromRoot(modulePath);
+  private packageJsonResolver: PackageJsonResolver = (packageName) =>
+    this.requireFromRoot.resolve(`${packageName}/package.json`);
 
   constructor() {
     const databaseUrl = process.env.DATABASE_URL?.trim();
@@ -172,11 +203,8 @@ export class PluginMarketService {
     }
 
     return this.withTenantContext(tenantId, async (client) => {
-      const versionResult = await client.query<{
-        min_platform_version: string | null;
-        version: string;
-      }>(
-        `SELECT version, min_platform_version
+      const versionResult = await client.query<InstallPluginVersionRow>(
+        `SELECT version, min_platform_version, manifest, server_package
          FROM plugin_versions
          WHERE plugin_id = $1 AND version = $2`,
         [pluginId, version]
@@ -206,6 +234,15 @@ export class PluginMarketService {
         [tenantId, pluginId, version]
       );
 
+      await this.runLifecycleHook(client, {
+        hookPath: selectedVersion.manifest.lifecycle?.onInstall,
+        manifest: selectedVersion.manifest,
+        pluginId,
+        serverPackage: selectedVersion.server_package,
+        tenantId,
+        version,
+      });
+
       return {
         enabled: true,
         pluginId,
@@ -225,6 +262,27 @@ export class PluginMarketService {
     }
 
     return this.withTenantContext(tenantId, async (client) => {
+      const lifecycleResult = await client.query<InstalledPluginLifecycleRow>(
+        `SELECT tp.installed_version, pv.manifest, pv.server_package
+         FROM tenant_plugins tp
+         LEFT JOIN plugin_versions pv
+           ON pv.plugin_id = tp.plugin_name
+          AND pv.version = tp.installed_version
+         WHERE tp.tenant_id = $1 AND tp.plugin_name = $2`,
+        [tenantId, pluginId]
+      );
+
+      const installedPlugin = lifecycleResult.rows[0];
+
+      await this.runLifecycleHook(client, {
+        hookPath: installedPlugin?.manifest?.lifecycle?.onUninstall,
+        manifest: installedPlugin?.manifest ?? null,
+        pluginId,
+        serverPackage: installedPlugin?.server_package ?? null,
+        tenantId,
+        version: installedPlugin?.installed_version ?? null,
+      });
+
       await client.query(
         `DELETE FROM tenant_plugins
          WHERE tenant_id = $1 AND plugin_name = $2
@@ -398,4 +456,64 @@ export class PluginMarketService {
 
     return new Date(value).toISOString();
   }
+
+  private async runLifecycleHook(
+    client: PoolClient,
+    input: {
+      hookPath?: string;
+      manifest: PluginManifest | null;
+      pluginId: string;
+      serverPackage: string | null;
+      tenantId: string;
+      version: string | null;
+    }
+  ): Promise<void> {
+    const hookPath = input.hookPath?.trim();
+
+    if (!hookPath || !input.manifest || !input.serverPackage || !input.version) {
+      return;
+    }
+
+    const packageRoot = dirname(
+      this.packageJsonResolver(this.extractPackageName(input.serverPackage))
+    );
+    const handler = this.resolveLifecycleHandler(
+      this.hookModuleLoader(resolve(packageRoot, hookPath)),
+      hookPath
+    );
+
+    await handler({
+      client,
+      manifest: input.manifest,
+      pluginId: input.pluginId,
+      tenantId: input.tenantId,
+      version: input.version,
+    });
+  }
+
+  private extractPackageName(serverPackage: string): string {
+    const versionSeparatorIndex = serverPackage.lastIndexOf('@');
+
+    if (versionSeparatorIndex > 0) {
+      return serverPackage.slice(0, versionSeparatorIndex);
+    }
+
+    return serverPackage;
+  }
+
+  private resolveLifecycleHandler(loadedModule: unknown, hookPath: string): PluginLifecycleHandler {
+    if (typeof loadedModule === 'function') {
+      return loadedModule as PluginLifecycleHandler;
+    }
+
+    if (isRecord(loadedModule) && typeof loadedModule.default === 'function') {
+      return loadedModule.default as PluginLifecycleHandler;
+    }
+
+    throw new Error(`Lifecycle hook '${hookPath}' must export a function`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }

--- a/docs/architecture/pluginMarketplacePlan.md
+++ b/docs/architecture/pluginMarketplacePlan.md
@@ -218,6 +218,8 @@ ALTER TABLE tenant_plugins ADD COLUMN installed_at TIMESTAMPTZ DEFAULT now();
 POST /install { pluginId, version }
   1. 从 plugin_versions 获取 manifest + bundle_url + server_package
   2. npm install server_package（或从 CDN 拉取）
+     - 状态（2026-04-08）：`T-P5-BE-04` 仅实现 lifecycle 调用机制，假设插件包已存在于
+       `node_modules`；动态安装/拉取仍为后续工作项，当前不在该任务 scope 内
   3. 执行 lifecycle.onInstall（数据库迁移等）
   4. 写入 tenant_plugins（enabled=true, installed_version=version）
   5. 返回成功 → 前端刷新插件列表

--- a/scripts/applySqlMigration.cjs
+++ b/scripts/applySqlMigration.cjs
@@ -134,12 +134,37 @@ async function applyMigration(client, migration) {
   }
 }
 
-async function run() {
-  const client = new Client({
-    connectionString: databaseUrl,
-  });
+async function connectWithRetry(maxAttempts = 30, delayMs = 1000) {
+  let lastError;
 
-  await client.connect();
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const client = new Client({
+      connectionString: databaseUrl,
+    });
+
+    try {
+      await client.connect();
+      return client;
+    } catch (error) {
+      lastError = error;
+      await client.end().catch(() => undefined);
+
+      if (attempt === maxAttempts) {
+        break;
+      }
+
+      console.log(
+        `[db:migrate] database not ready yet (${attempt}/${maxAttempts}); retrying in ${delayMs}ms`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw lastError;
+}
+
+async function run() {
+  const client = await connectWithRetry();
   await ensureMigrationTable(client);
 
   const migrations = readMigrationFiles();


### PR DESCRIPTION
## Summary
- add a real PostgreSQL integration test and fixture for plugin install/uninstall lifecycle hooks
- execute manifest lifecycle hooks inside tenant-scoped install/uninstall transactions in `PluginMarketService`
- harden SQL migration bootstrap with retry logic so fresh integration environments do not race Postgres startup

## Verification
- npm run test:coreApi -- --run apps/coreApi/src/modules/plugin/pluginMarketService.test.ts
- npm run test:coreApi:integration -- --run apps/coreApi/src/__tests__/integration/pluginLifecycle.integration.test.ts
- npx prettier --check apps/coreApi/src/modules/plugin/pluginMarketService.ts apps/coreApi/src/modules/plugin/pluginMarketService.test.ts apps/coreApi/src/__tests__/integration/pluginLifecycle.integration.test.ts scripts/applySqlMigration.cjs
- git diff --check