### PR TITLE
test(plugin): install hook rollback case (BE-02 follow-up)

### DIFF
--- a/apps/coreApi/src/modules/plugin/pluginMarketService.test.ts
+++ b/apps/coreApi/src/modules/plugin/pluginMarketService.test.ts
@@ -441,6 +441,59 @@ describe('PluginMarketService', () => {
       );
       expect(mockClient.calls[3]?.sql).toContain('INSERT INTO tenant_plugins');
     });
+
+    it('rolls back the tenant_plugins insert when the install hook throws', async () => {
+      const lifecycleHook = vi.fn(async () => {
+        throw new Error('install hook failed');
+      });
+      const hookModuleLoader = vi.fn(() => lifecycleHook);
+      const packageJsonResolver = vi.fn(
+        () => '/repo/node_modules/@nodeadmin/plugin-kanban/package.json'
+      );
+      const mockClient = createMockClient([
+        { rows: [], rowCount: 0 },
+        { rows: [], rowCount: 0 },
+        {
+          rows: [
+            {
+              manifest: {
+                author: { name: 'NodeAdmin Team' },
+                description: 'Board view',
+                displayName: 'Kanban',
+                engines: { nodeAdmin: '>=0.1.0' },
+                entrypoints: { server: './dist/server/index.js' },
+                id: '@nodeadmin/plugin-kanban',
+                lifecycle: { onInstall: './scripts/install.cjs' },
+                permissions: ['backlog:view'],
+                version: '1.2.0',
+              },
+              min_platform_version: '>=0.1.0',
+              server_package: '@nodeadmin/plugin-kanban@1.2.0',
+              version: '1.2.0',
+            },
+          ],
+          rowCount: 1,
+        },
+        { rows: [], rowCount: 1 },
+        { rows: [], rowCount: 0 },
+      ]);
+      const mockPool = createMockPool([]);
+      mockPool.connect = vi.fn(async () => mockClient);
+      (service as unknown as { pool: typeof mockPool }).pool = mockPool;
+      (service as unknown as { hookModuleLoader: typeof hookModuleLoader }).hookModuleLoader =
+        hookModuleLoader;
+      (
+        service as unknown as { packageJsonResolver: typeof packageJsonResolver }
+      ).packageJsonResolver = packageJsonResolver;
+
+      await expect(
+        service.installPlugin('tenant-1', '@nodeadmin/plugin-kanban', '1.2.0')
+      ).rejects.toThrow('install hook failed');
+
+      expect(mockClient.calls[3]?.sql).toContain('INSERT INTO tenant_plugins');
+      expect(mockClient.calls.at(-1)?.sql).toBe('ROLLBACK');
+      expect(mockClient.calls.some((call) => call.sql === 'COMMIT')).toBe(false);
+    });
   });
 
   describe('publishPlugin', () => {


### PR DESCRIPTION
## Summary
- add a unit test covering the install lifecycle failure path in `pluginMarketService`
- assert that a throwing install hook propagates the error and leaves the tenant-scoped transaction in `ROLLBACK` instead of `COMMIT`
- close the follow-up that was intentionally deferred from PR #49 until PR #47 landed on `master`

## Verification
- `npm run lint`
- `npm run format:check`
- `npm run test:coreApi -- --run apps/coreApi/src/modules/plugin/pluginMarketService.test.ts`

## Context from PR #49

PR #49 carried this follow-up explicitly:

> This PR does NOT include the plugin install hook rollback test case
> that was originally planned in M-122 / M-123. Reason: the rollback
> test depends on the lifecycle hook implementation in PR #47 (T-P5-BE-04),
> which has not yet merged to master. BE-02 was branched from master
> 11546bb which predates that implementation.
>
> Once #47 lands on master, a follow-up PR will:
> 1. Add a `pluginMarketService.test.ts` case asserting that an install
>    hook throwing an error rolls back the tenant_plugins INSERT
>    (BEGIN/COMMIT/ROLLBACK transaction in withTenantContext).
> 2. Optionally add a corresponding integration test case if the unit
>    coverage proves insufficient.
